### PR TITLE
EnvFile class init

### DIFF
--- a/packages/restlessness-utilities/package-lock.json
+++ b/packages/restlessness-utilities/package-lock.json
@@ -2419,6 +2419,11 @@
         }
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/packages/restlessness-utilities/package.json
+++ b/packages/restlessness-utilities/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@types/lodash.unset": "4.5.6",
+    "dotenv": "8.2.0",
     "lodash.merge": "4.6.2",
     "lodash.unset": "4.5.2",
     "rimraf": "3.0.2",

--- a/packages/restlessness-utilities/src/EnvFile/index.ts
+++ b/packages/restlessness-utilities/src/EnvFile/index.ts
@@ -1,0 +1,54 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import PathResolver from '../PathResolver';
+import { parse } from 'dotenv';
+
+export default class EnvFile {
+  private static get envsPath(): string {
+    return PathResolver.getEnvsPath;
+  }
+
+  private get currentEnvPath(): string {
+    return path.join(EnvFile.envsPath, `.env.${this.envName}`);
+  }
+
+  private static get generatedEnvPath(): string {
+    return path.join(PathResolver.getPrjPath, '.env');
+  }
+
+  constructor(private envName: string) {
+  }
+
+  private async readEnv(): Promise<{ [key: string]: string }> {
+    const envFile = await fs.readFile(this.currentEnvPath);
+    return parse(envFile.toString());
+  }
+
+  private static async write(filePath: string, env: { [key: string]: string }) {
+    let output = '';
+    for (let key in env) {
+      output += `${key}='${env[key]}'\n`;
+    }
+    await fs.writeFile(filePath, output);
+  }
+
+  private async writeCurrentEnv(env: { [key: string]: string }) {
+    await EnvFile.write(this.currentEnvPath, env);
+  }
+
+  async getValue(key: string): Promise<string> {
+    const env = await this.readEnv();
+    return env[key];
+  }
+
+  async setValue(key: string, value: string) {
+    const env = await this.readEnv();
+    env[key] = value;
+    await this.writeCurrentEnv(env);
+  }
+
+  async generate(): Promise<void> {
+    const env = await this.readEnv();
+    await EnvFile.write(EnvFile.generatedEnvPath, env);
+  }
+}


### PR DESCRIPTION
instead of having 2 classes (a singleton for ./.env and a regular class for each different env) we could implement both functionalities on this class, since the flow would be something like this:

`const locale = new EnvFile('locale')`
`locale.setValue('secret', 'hello')` to modify the specific env under `envs/.env.locale`
and then `locale.generate()` to generate the file `root/.env`