### PR TITLE
minor fix:

### DIFF
--- a/packages/restlessness-cli/src/commands/dev/index.ts
+++ b/packages/restlessness-cli/src/commands/dev/index.ts
@@ -1,5 +1,4 @@
 import minimist from 'minimist';
-import serve from 'serve-handler';
 import path from 'path';
 import { spawn } from 'child_process';
 
@@ -10,7 +9,7 @@ export default async (argv: minimist.ParsedArgs) => {
   }
 
   const backend = spawn('serverless', ['offline', '--port', '4123'], {
-    cwd: path.join(__dirname, '..', '..', 'assets', 'backend'),
+    cwd: path.join(__dirname, '..', '..', '..', 'lib', 'assets', 'backend'),
     env: {
       ...process.env,
       RLN_PROJECT_PATH: process.cwd(),

--- a/packages/restlessness-utilities/src/AddOnPackage/index.ts
+++ b/packages/restlessness-utilities/src/AddOnPackage/index.ts
@@ -1,10 +1,10 @@
 import path from 'path';
 import PathResolver from '../PathResolver';
+import AWSLambda from 'aws-lambda';
 
 export default abstract class AddOnPackage {
   static load<T>(packageName: string): T {
-    const pkg: T = require(path.join(PathResolver.getNodeModulesPath, packageName));
-    return pkg;
+    return require(path.join(PathResolver.getNodeModulesPath, packageName));
   }
 
   abstract async postInstall(): Promise<void>


### PR DESCRIPTION
rln-cli dev command fixed wrong path
rln-utilities added import for aws-lambda, prevent compiler fail when including rln-utilities as dependencies (types were not exported)