### PR TITLE
Fixed bug when checking if user was already subscribed to plan

### DIFF
--- a/packages/plugins/braintree/src/braintree/index.ts
+++ b/packages/plugins/braintree/src/braintree/index.ts
@@ -128,7 +128,7 @@ class Braintree {
 
     async isAlreadySubscribed(planId: string, customerId: string): Promise<boolean> {
         const customer = await this.getCustomerById(customerId);
-        return customer.paymentMethods.some(cc => cc.subscriptions.some(sub => sub.planId === planId));
+        return customer.paymentMethods.some(cc => cc.subscriptions.some(sub => (sub.planId === planId && sub.status === 'Active')));
     }
 
     async cancelUserSubscription(customerId: string, subscriptionId: string): Promise<boolean> {

--- a/packages/plugins/braintree/src/braintree/index.ts
+++ b/packages/plugins/braintree/src/braintree/index.ts
@@ -126,6 +126,11 @@ class Braintree {
         }, []);
     }
 
+    async getUserActiveSubscriptions(customerId: string) {
+        const subscriptions = await this.getUserSubscriptions(customerId);
+        return subscriptions.filter(sub => sub.status === 'Active');
+    }
+
     async isAlreadySubscribed(planId: string, customerId: string): Promise<boolean> {
         const customer = await this.getCustomerById(customerId);
         return customer.paymentMethods.some(cc => cc.subscriptions.some(sub => (sub.planId === planId && sub.status === 'Active')));


### PR DESCRIPTION
Quando controllavo se un utente avesse già un'iscrizione a un determinato piano, non controllavo se lo stato di tale abbonamento fosse "Active", ora il controllo viene fatto ed è tutto ok